### PR TITLE
callback inside of try block can obscure errors

### DIFF
--- a/lib/nconf/stores/file.js
+++ b/lib/nconf/stores/file.js
@@ -97,12 +97,13 @@ File.prototype.load = function (callback) {
     
     try {
       self.store = self.format.parse(data.toString());
-      callback(null, self.store);
     }
     catch (ex) {
       self.store = {};
-      callback(ex);
+      return callback(ex);
     }
+    callback(null, self.store);
+
   });
 };
 


### PR DESCRIPTION
this pattern is dangerous:

```
try {
  callback(null,parseOrSomething())
} catch (err){
  callback(err)
}
```

Because if you callback from within the try, and then the callback throws an error, then the catch will catch the error, and the callback will be called a second time, now in the error state.

as you can imagine, this can make debugging or testing more confusing that necessary.

cheers. Dominic 
