### PR TITLE
added showHelp() to exported nconf, so that optimist help can be printed

### DIFF
--- a/lib/nconf.js
+++ b/lib/nconf.js
@@ -7,6 +7,7 @@
 
 var fs = require('fs'),
     async = require('async'),
+    optimist = require('optimist'),
     common = require('./nconf/common'),
     Provider = require('./nconf/provider').Provider,
     nconf = module.exports = new Provider();
@@ -37,3 +38,4 @@ nconf.loadFiles     = common.loadFiles;
 nconf.loadFilesSync = common.loadFilesSync;
 nconf.formats       = require('./nconf/formats');
 nconf.Provider      = Provider;
+nconf.showHelp      = function() {  this.opti = this.opti || optimist.options(nconf.stores.argv.options); this.opti.showHelp(); };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "async": "0.1.x",
     "ini": "1.x.x",
-    "optimist": "0.2.x",
+    "optimist": "0.3.x",
     "pkginfo": "0.2.x"
   },
   "devDependencies": {


### PR DESCRIPTION
bumped optimist to 0.3.x
