### PR TITLE
Surfacing additional JSON.stringify arguments in formats.json.stringify, and in the File constructor

### DIFF
--- a/lib/nconf/formats.js
+++ b/lib/nconf/formats.js
@@ -14,8 +14,8 @@ var formats = exports;
 // Standard JSON format which pretty prints `.stringify()`.
 //
 formats.json = {
-  stringify: function (obj) {
-    return JSON.stringify(obj, null, 2)
+  stringify: function (obj, replacer, spacing) {
+    return JSON.stringify(obj, replacer || null, spacing || 2)
   },
   parse: JSON.parse
 };

--- a/lib/nconf/stores/file.js
+++ b/lib/nconf/stores/file.js
@@ -29,6 +29,7 @@ var File = exports.File = function (options) {
   this.file   = options.file;
   this.dir    = options.dir    || process.cwd();
   this.format = options.format || formats.json;
+  this.json_spacing = options.json_spacing || 2;
   
   if (options.search) {
     this.search(this.dir);
@@ -51,7 +52,7 @@ File.prototype.save = function (value, callback) {
     value = null;
   }
   
-  fs.writeFile(this.file, this.format.stringify(this.store), function (err) {
+  fs.writeFile(this.file, this.format.stringify(this.store, null, this.json_spacing), function (err) {
     return err ? callback(err) : callback();
   });
 };
@@ -65,7 +66,7 @@ File.prototype.save = function (value, callback) {
 //
 File.prototype.saveSync = function (value) {
   try {
-    fs.writeFileSync(this.file, this.format.stringify(this.store));
+    fs.writeFileSync(this.file, this.format.stringify(this.store, null, this.json_spacing));
   }
   catch (ex) {
     throw(ex);
@@ -224,4 +225,3 @@ File.prototype.search = function (base) {
   
   return fullpath;
 };
-


### PR DESCRIPTION
Surfacing additional JSON.stringify arguments in formats.json.stringify, and adding the json_spacing option to the File constructor.

This is the foundational work required to resolve https://github.com/nodejitsu/jitsu/issues/208 - and it will allow consistent JSON formatting for devs that don't use 2-space indentation.
