### PR TITLE
Add reset to the list of destructive commands

### DIFF
--- a/lib/nconf/provider.js
+++ b/lib/nconf/provider.js
@@ -473,7 +473,7 @@ Provider.prototype.save = function (value, callback) {
 Provider.prototype._execute = function (action, syncLength /* [arguments] */) {
   var args = Array.prototype.slice.call(arguments, 2),
       callback = typeof args[args.length - 1] === 'function' && args.pop(),
-      destructive = ['set', 'clear', 'merge'].indexOf(action) !== -1,
+      destructive = ['set', 'clear', 'merge', 'reset'].indexOf(action) !== -1,
       self = this,
       response;
 


### PR DESCRIPTION
To be honest, `get` is the only `_execute` command that's _not_ destructive, so I'd be leaning towards just checking for that... just didn't want to rock the boat too much :-)
