### PR TITLE
Fix ini files for memory loadFrom option

### DIFF
--- a/lib/nconf/common.js
+++ b/lib/nconf/common.js
@@ -58,7 +58,7 @@ common.loadFiles = function (files, callback) {
     });
   }
 
-  async.map(files, parseFile, function (err, objs) {
+  async.map(options.files, parseFile, function (err, objs) {
     return err ? callback(err) : callback(null, common.merge(objs));
   });
 };
@@ -80,7 +80,7 @@ common.loadFilesSync = function (files) {
   var options = Array.isArray(files) ? { files: files } : files;
   options.format = options.format || formats.json;
 
-  return common.merge(files.map(function (file) {
+  return common.merge(options.files.map(function (file) {
     return options.format.parse(fs.readFileSync(file, 'utf8'));
   }));
 };


### PR DESCRIPTION
make it possible to use other formats than json in common.loadFiles and common.loadFilesSync
