### PR TITLE
Use optionally a different separator for memorystore 

### DIFF
--- a/lib/nconf/common.js
+++ b/lib/nconf/common.js
@@ -19,8 +19,9 @@ var common = exports;
 // If given null or undefined it should return an empty path.
 // '' should still be respected as a path.
 //
-common.path = function (key) {
-  return key == null ? [] : key.split(':');
+common.path = function (key, separator) {
+  separator = separator || ':';
+  return key == null ? [] : key.split(separator);
 };
 
 //
@@ -29,6 +30,15 @@ common.path = function (key) {
 //
 common.key = function () {
   return Array.prototype.slice.call(arguments).join(':');
+};
+
+//
+// ### function key (arguments)
+// Returns a joined string from the `arguments`,
+// first argument is the join delimiter.
+//
+common.keyed = function () {
+  return Array.prototype.slice.call(arguments, 1).join(arguments[0]);
 };
 
 //

--- a/lib/nconf/stores/memory.js
+++ b/lib/nconf/stores/memory.js
@@ -22,6 +22,7 @@ var Memory = exports.Memory = function (options) {
   this.mtimes   = {};
   this.readOnly = false;
   this.loadFrom = options.loadFrom || null;
+  this.logicalSeparator = options.logicalSeparator || ':';
 
   if (this.loadFrom) {
     this.store = common.loadFilesSync(this.loadFrom);
@@ -35,7 +36,7 @@ var Memory = exports.Memory = function (options) {
 //
 Memory.prototype.get = function (key) {
   var target = this.store,
-      path   = common.path(key);
+      path   = common.path(key, this.logicalSeparator);
 
   //
   // Scope into the object to get the appropriate nested context
@@ -64,7 +65,7 @@ Memory.prototype.set = function (key, value) {
   }
 
   var target = this.store,
-      path   = common.path(key);
+      path   = common.path(key, this.logicalSeparator);
 
   if (path.length === 0) {
     //
@@ -115,7 +116,7 @@ Memory.prototype.clear = function (key) {
 
   var target = this.store,
       value  = target,
-      path   = common.path(key);
+      path   = common.path(key, this.logicalSeparator);
 
   //
   // Remove the key from the set of `mtimes` (modified times)
@@ -163,7 +164,7 @@ Memory.prototype.merge = function (key, value) {
 
   var self    = this,
       target  = this.store,
-      path    = common.path(key),
+      path    = common.path(key, this.logicalSeparator),
       fullKey = key;
 
   //
@@ -197,7 +198,7 @@ Memory.prototype.merge = function (key, value) {
   }
 
   return Object.keys(value).every(function (nested) {
-    return self.merge(common.key(fullKey, nested), value[nested]);
+    return self.merge(common.keyed(self.logicalSeparator, fullKey, nested), value[nested]);
   });
 };
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -13,6 +13,8 @@ var assert = require('assert'),
     nconf = require('../lib/nconf');
 
 exports.assertMerged = function (err, merged) {
+  console.log(merged);
+  
   merged = merged instanceof nconf.Provider 
     ? merged.store.store
     : merged;

--- a/test/stores/memory-store-test.js
+++ b/test/stores/memory-store-test.js
@@ -104,5 +104,22 @@ vows.describe('nconf/stores/memory').addBatch({
         assert.equal(store.get('merge:object:prop4').length, 2);        
       }
     }
+  },
+  "When using the nconf memory store with different logical separator": {
+    topic: new nconf.Memory({logicalSeparator: '||' }),
+    "when storing with : (colon)": {
+      "should store the config atomicly": function (store) {
+        store.set('foo:bar:bazz', 'buzz');
+        assert.isTrue(typeof store.get('foo:bar') === 'undefined');
+        assert.equal(store.get('foo:bar:bazz'), 'buzz');
+      }
+    },
+    "when storing with separator": {
+      "should be able to read the object": function (store) {
+        store.set('foo||bar||bazz', 'buzz');
+        assert.equal(store.get('foo||bar').bazz, 'buzz');
+        assert.equal(store.get('foo').bar.bazz, 'buzz');
+      }
+    }
   }
 }).export(module);


### PR DESCRIPTION
I want to be able to have a different separator for the memorystore (and thus for file). For instance when I store a config like this `foo:bar:baz` I want that to be stored as a whole not nested.

``` javascript
nconf.file({file: 'config.json', separator: '||'});

nconf.set('foo:bar:baz', 123);
nconf.set('baz||bar', 456);

nconf.save()
```

Will save this:

``` javascript
{
  "foo:bar:baz": 123,
  "baz": { "bar": 456 }
}
```
