### PR TITLE
Use provided `dir` path when loading file

### DIFF
--- a/lib/nconf/stores/file.js
+++ b/lib/nconf/stores/file.js
@@ -29,6 +29,7 @@ var File = exports.File = function (options) {
   this.type   = 'file';
   this.file   = options.file;
   this.dir    = options.dir    || process.cwd();
+  this.fullPath = path.join(this.dir, this.file);
   this.format = options.format || formats.json;
   this.json_spacing = options.json_spacing || 2;
 
@@ -53,7 +54,7 @@ File.prototype.save = function (value, callback) {
     value = null;
   }
 
-  fs.writeFile(this.file, this.format.stringify(this.store, null, this.json_spacing), function (err) {
+  fs.writeFile(this.fullPath, this.format.stringify(this.store, null, this.json_spacing), function (err) {
     return err ? callback(err) : callback();
   });
 };
@@ -67,7 +68,7 @@ File.prototype.save = function (value, callback) {
 //
 File.prototype.saveSync = function (value) {
   try {
-    fs.writeFileSync(this.file, this.format.stringify(this.store, null, this.json_spacing));
+    fs.writeFileSync(this.fullPath, this.format.stringify(this.store, null, this.json_spacing));
   }
   catch (ex) {
     throw(ex);
@@ -83,7 +84,7 @@ File.prototype.saveSync = function (value) {
 File.prototype.load = function (callback) {
   var self = this;
 
-  exists(self.file, function (exists) {
+  exists(this.fullPath, function (exists) {
     if (!exists) {
       return callback(null, {});
     }
@@ -91,7 +92,7 @@ File.prototype.load = function (callback) {
     //
     // Else, the path exists, read it from disk
     //
-    fs.readFile(self.file, function (err, data) {
+    fs.readFile(this.fullPath, function (err, data) {
       if (err) {
         return callback(err);
       }
@@ -116,7 +117,7 @@ File.prototype.load = function (callback) {
 File.prototype.loadSync = function () {
   var data, self = this;
 
-  if (!existsSync(self.file)) {
+  if (!existsSync(this.fullPath)) {
     self.store = {};
     data = {};
   }
@@ -125,7 +126,7 @@ File.prototype.loadSync = function () {
     // Else, the path exists, read it from disk
     //
     try {
-      data = this.format.parse(fs.readFileSync(this.file, 'utf8'));
+      data = this.format.parse(fs.readFileSync(this.fullPath, 'utf8'));
       this.store = data;
     }
     catch (ex) {


### PR DESCRIPTION
enable nconf to find config files when not in base folder (ie. not process.cwd())

nconf was not finding my config files when it wasn't in the base folder
