### PR TITLE
filter process.env by regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,12 @@ Responsible for loading the values parsed from `process.env` into the configurat
   var dbHost = nconf.get('database:host');
 
   //
-  // Or use both options
+  // Or use all options
   //
   nconf.env({
     separator: '__',
-    whitelist: ['database__host', 'only', 'load', 'these', 'values']
+    match: /^whatever_matches_this_will_be_whitelisted/
+    whitelist: ['database__host', 'only', 'load', 'these', 'values', 'if', 'whatever_doesnt_match_but_is_whitelisted_gets_loaded_too']
   });
   var dbHost = nconf.get('database:host');
 ```

--- a/lib/nconf/stores/env.js
+++ b/lib/nconf/stores/env.js
@@ -53,7 +53,9 @@ Env.prototype.loadEnv = function () {
 
   this.readOnly = false;
   Object.keys(process.env).filter(function (key) {
-    if(self.match) {
+    if(self.match && self.whitelist.length) {
+      return key.match(self.match) || self.whitelist.indexOf(key) !== -1
+    } else if (self.match) {
       return key.match(self.match)
     } else {
       return !self.whitelist.length || self.whitelist.indexOf(key) !== -1


### PR DESCRIPTION
adds match option for pattern matching when filtering process.env variables... for example

``` js
config = nconf.env({
    separator: '_',
    match: /^prefix/,
    whitelist: ["cumbaya"]
})
```

in this case all the variables that match the regexp are whitelisted... whatever is in whitelist still gets loaded

this is some handy dandy project.. awesome! thanks!
