### PR TITLE
Delete CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# CHANGELOG
-
-### Version 0.5.0
-
-* `nconf.stores.*` is now `nconf.*`
-* `nconf.stores` now represents the set of nconf.* Store instances on the nconf object.
-* Added `nconf.argv()`, `nconf.env()`, `nconf.file()`, `nconf.overrides()`, `nconf.defaults()`. 
-* `nconf.system` no longer exists. The `nconf.System` store has been broken into `nconf.Argv`, `nconf.Env` and `nconf.Literal`
-* Fixed bugs in hierarchical configuration loading.


### PR DESCRIPTION
Changelog not updated for more than 2 years, it is better to remove it so as not to mislead.
