### PR TITLE
Passing the value parameter to the providers

### DIFF
--- a/lib/nconf/provider.js
+++ b/lib/nconf/provider.js
@@ -208,6 +208,13 @@ Provider.prototype.init = function (options) {
 // Retrieves the value for the specified key (if any).
 //
 Provider.prototype.get = function (key, callback) {
+    
+  // Allow a * key call to be made
+  if (typeof key === 'function') {
+      callback = key;
+      key = null;
+  }
+    
   //
   // If there is no callback we can short-circuit into the default
   // logic for traversing stores.
@@ -215,7 +222,7 @@ Provider.prototype.get = function (key, callback) {
   if (!callback) {
     return this._execute('get', 1, key, callback);
   }
-
+  
   //
   // Otherwise the asynchronous, hierarchical `get` is
   // slightly more complicated because we do not need to traverse

--- a/lib/nconf/provider.js
+++ b/lib/nconf/provider.js
@@ -460,7 +460,7 @@ Provider.prototype.save = function (value, callback) {
     //
 
     if (store.save) {
-      return store.save(function (err, data) {
+      return store.save(value, function (err, data) {
         if (err) {
           return next(err);
         }


### PR DESCRIPTION
The nconf-redis provider needs the value for some reason, if its absent
this call will fail. It should be there anyway.