### PR TITLE
[fix] have latter stores precede the former stores.

### DIFF
--- a/lib/nconf/provider.js
+++ b/lib/nconf/provider.js
@@ -222,7 +222,7 @@ Provider.prototype.get = function (key, callback) {
   // the entire set of stores, but up until there is a defined value.
   //
   var current = 0,
-      names = Object.keys(this.stores),
+      names = Object.keys(this.stores).reverse(),
       self = this,
       response,
       mergeObjs = [];


### PR DESCRIPTION
This fixes a problem with broadway's setting of `env` and it seems natural that stores added later should take precedence over say the `literal` store.
