### PR TITLE
Adding helpful information in case parsing failed.

### DIFF
--- a/lib/nconf/stores/file.js
+++ b/lib/nconf/stores/file.js
@@ -105,7 +105,7 @@ File.prototype.load = function (callback) {
 
       }
       catch (ex) {
-        return callback(new Error("Error parsing your JSON configuration file: [" + self.file + '].'));
+        return callback(new Error("Error parsing your configuration file: [" + self.file + ']: ' + ex.message));
       }
 
       callback(null, self.store);
@@ -138,7 +138,7 @@ File.prototype.loadSync = function () {
       this.store = data;
     }
     catch (ex) {
-      throw new Error("Error parsing your JSON configuration file: [" + self.file + '].');
+      throw new Error("Error parsing your configuration file: [" + self.file + ']: ' + ex.message);
     }
   }
 


### PR DESCRIPTION
I stumbled over 2 slight problems of broken configuration files:

1) It said that a error in my JSON file existed (even though it was a yaml file, parsed by libyaml)
2) It didn't tell me which error occured.

both should be fixed with this PR
