### PR TITLE
Easier plugable formats and remove ini format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 .DS_Store
 config.json
 test/fixtures/*.json
+test/fixtures/*.yaml
 test/fixtures/foo.bar
 !test/fixtures/complete.json
 !test/fixtures/malformed.json
+!test/fixtures/malformed.yaml
 !test/fixtures/bom.json
 !test/fixtures/no-bom.json
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 config.json
 test/fixtures/*.json
+test/fixtures/foo.bar
 !test/fixtures/complete.json
 !test/fixtures/malformed.json
 !test/fixtures/bom.json

--- a/README.md
+++ b/README.md
@@ -223,6 +223,25 @@ Based on the Memory store, but provides additional methods `.save()` and `.load(
 
 The file store is also extensible for multiple file formats, defaulting to `JSON`. To use a custom format, simply pass a format object to the `.use()` method. This object must have `.parse()` and `.stringify()` methods just like the native `JSON` object.
 
+``` js
+nconf.file({
+  file: '/path/to/some/file.ini',
+  format: require('ini')
+});
+```
+
+You can also specify additional formats by populating `nconf.formats`. Eg.
+
+``` js
+nconf.formats.yaml = require('nconf-yaml');
+
+// And then do
+nconf.file({ file: '/path/to/some/file', format: 'yaml' })
+
+// or
+nconf.file({ file: '/path/to/some/file.yaml' }) // note the file extension
+```
+
 If the file does not exist at the provided path, the store will simply be empty.
 
 ### Redis

--- a/lib/nconf/common.js
+++ b/lib/nconf/common.js
@@ -6,6 +6,7 @@
  */
 
 var fs = require('fs'),
+    path = require('path'),
     async = require('async'),
     formats = require('./formats'),
     Memory = require('./stores/memory').Memory;
@@ -42,6 +43,24 @@ common.keyed = function () {
 };
 
 //
+// ### function getFileFormat (file, format)
+// Detect file format and return format object
+//
+common.getFileFormat = function (file, format) {
+  format = format || path.extname(this.file).slice(1);
+
+  if (typeof format === 'string' && formats[format]) {
+    format = formats[format];
+  }
+
+  if (!format.parse || !format.stringify) {
+    format = formats.json;
+  }
+
+  return format;
+};
+
+//
 // ### function loadFiles (files, callback)
 // #### @files {Object|Array} List of files (or settings object) to load.
 // #### @callback {function} Continuation to respond to when complete.
@@ -54,16 +73,11 @@ common.loadFiles = function (files, callback) {
 
   var options = Array.isArray(files) ? { files: files } : files;
 
-  //
-  // Set the default JSON format if not already
-  // specified
-  //
-  options.format = options.format || formats.json;
-
   function parseFile (file, next) {
     fs.readFile(file, function (err, data) {
+      var format = common.getFileFormat(file, options.format);
       return !err
-        ? next(null, options.format.parse(data.toString()))
+        ? next(null, format.parse(data.toString()), options.formatOptions)
         : next(err);
     });
   }
@@ -83,15 +97,11 @@ common.loadFilesSync = function (files) {
     return;
   }
 
-  //
-  // Set the default JSON format if not already
-  // specified
-  //
   var options = Array.isArray(files) ? { files: files } : files;
-  options.format = options.format || formats.json;
 
   return common.merge(options.files.map(function (file) {
-    return options.format.parse(fs.readFileSync(file, 'utf8'));
+    var format = common.getFileFormat(file, options.format);
+    return format.parse(fs.readFileSync(file, 'utf8'), options.formatOptions);
   }));
 };
 

--- a/lib/nconf/formats.js
+++ b/lib/nconf/formats.js
@@ -12,8 +12,12 @@ var formats = exports;
 // Standard JSON format which pretty prints `.stringify()`.
 //
 formats.json = {
-  stringify: function (obj, replacer, spacing) {
-    return JSON.stringify(obj, replacer || null, spacing || 2)
+  stringify: function (value, options) {
+    options = options || {};
+    return JSON.stringify(value, options.replacer || null, options.spacing || 2)
   },
-  parse: JSON.parse
+  parse: function (text, options) {
+    options = options || {};
+    return JSON.parse(text, options.reviver)
+  }
 };

--- a/lib/nconf/formats.js
+++ b/lib/nconf/formats.js
@@ -5,8 +5,6 @@
  *
  */
 
-var ini = require('ini');
-
 var formats = exports;
 
 //
@@ -19,10 +17,3 @@ formats.json = {
   },
   parse: JSON.parse
 };
-
-//
-// ### @ini
-// Standard INI format supplied from the `ini` module
-// http://en.wikipedia.org/wiki/INI_file
-//
-formats.ini = ini;

--- a/lib/nconf/stores/file.js
+++ b/lib/nconf/stores/file.js
@@ -8,6 +8,7 @@
 var fs = require('fs'),
     path = require('path'),
     util = require('util'),
+    common = require('../common'),
     formats = require('../formats'),
     Memory = require('./memory').Memory,
     exists = fs.exists || path.exists,
@@ -29,8 +30,11 @@ var File = exports.File = function (options) {
   this.type   = 'file';
   this.file   = options.file;
   this.dir    = options.dir    || process.cwd();
-  this.format = options.format || formats.json;
-  this.json_spacing = options.json_spacing || 2;
+  this.format = common.getFileFormat(this.file, options.format);
+  this.formatOptions = options.formatOptions || {};
+
+  // backward compatibility
+  if (options.json_spacing) this.formatOptions.spacing = options.json_spacing;
 
   if (options.search) {
     this.search(this.dir);
@@ -53,7 +57,7 @@ File.prototype.save = function (value, callback) {
     value = null;
   }
 
-  fs.writeFile(this.file, this.format.stringify(this.store, null, this.json_spacing), function (err) {
+  fs.writeFile(this.file, this.format.stringify(this.store, this.formatOptions), function (err) {
     return err ? callback(err) : callback();
   });
 };
@@ -67,7 +71,7 @@ File.prototype.save = function (value, callback) {
 //
 File.prototype.saveSync = function (value) {
   try {
-    fs.writeFileSync(this.file, this.format.stringify(this.store, null, this.json_spacing));
+    fs.writeFileSync(this.file, this.format.stringify(this.store, this.formatOptions));
   }
   catch (ex) {
     throw(ex);
@@ -101,7 +105,7 @@ File.prototype.load = function (callback) {
         var stringData = data.toString();
 
         if (stringData.charAt(0) === '\uFEFF') stringData = stringData.substr(1);
-        self.store = self.format.parse(stringData);
+        self.store = self.format.parse(stringData, self.formatOptions);
 
       }
       catch (ex) {
@@ -134,7 +138,7 @@ File.prototype.loadSync = function () {
       var fileData = fs.readFileSync(this.file, 'utf8');
       if (fileData.charAt(0) === '\uFEFF') fileData = fileData.substr(1);
 
-      data = this.format.parse(fileData);
+      data = this.format.parse(fileData, this.formatOptions);
       this.store = data;
     }
     catch (ex) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   ],
   "dependencies": {
     "async": "~0.9.0",
-    "ini": "1.x.x",
     "optimist": "~0.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "optimist": "~0.6.0"
   },
   "devDependencies": {
-    "vows": "0.8.x"
+    "vows": "0.8.x",
+    "nconf-yaml": "1.x.x",
+    "js-yaml": "3.x.x"
   },
   "main": "./lib/nconf",
   "scripts": {

--- a/test/fixtures/malformed.yaml
+++ b/test/fixtures/malformed.yaml
@@ -1,0 +1,2 @@
+foo: bar
+baz

--- a/test/stores/file-store-test.js
+++ b/test/stores/file-store-test.js
@@ -222,5 +222,40 @@ vows.describe('nconf/stores/file').addBatch({
       }
     }
   }
+}).addBatch({
+  "When using the nconf file store": {
+    "with custom stringify and parse options": {
+      topic: function () {
+        function stringify(obj) {
+          return 'foobar';
+        }
+        function parse(str) {
+          return { foo: 'bar' };
+        }
+        this.filePath = path.join(__dirname, '..', 'fixtures', 'foo.bar');
+        fs.writeFileSync(this.filePath, 'foobar');
+        var format = { stringify: stringify, parse: parse };
+        this.store = store = new nconf.File({ file: this.filePath, format: format });
+        return null;
+      },
+      "the load() method": {
+        topic: function () {
+          this.store.load(this.callback);
+        },
+        "should call the parse method": function (err, data) {
+          assert.isNull(err);
+          assert.deepEqual(data, { foo: 'bar' });
+        }
+      },
+      "the save method()": {
+        topic: function () {
+          this.store.save(this.callback);
+        },
+        "should call the stringify method": function (store) {
+          assert.equal(fs.readFileSync(this.filePath, 'utf8'), 'foobar');
+        }
+      }
+    }
+  }
 }).export(module);
 

--- a/test/stores/file-store-yaml-test.js
+++ b/test/stores/file-store-yaml-test.js
@@ -1,0 +1,116 @@
+/*
+ * format-yaml-test.js: Tests YAML file format.
+ *
+ * (C) 2011, Nodejitsu Inc.
+ *
+ */
+
+var fs = require('fs'),
+    path = require('path'),
+    vows = require('vows'),
+    assert = require('assert'),
+    nconf = require('../../lib/nconf'),
+    data = require('../fixtures/data').data,
+    YAML = require('js-yaml'),
+    store;
+
+vows.describe('nconf/formats yaml').addBatch({
+  "When using the nconf file store": {
+    "with a valid YAML file": {
+      topic: function () {
+        var filePath = path.join(__dirname, '..', 'fixtures', 'store.yaml');
+        fs.writeFileSync(filePath, YAML.safeDump(data));
+        this.store = store = new nconf.File({ file: filePath, format: require('nconf-yaml') });
+        return null;
+      },
+      "the load() method": {
+        topic: function () {
+          this.store.load(this.callback);
+        },
+        "should load the data correctly": function (err, data) {
+          assert.isNull(err);
+          assert.deepEqual(data, this.store.store);
+        }
+      }
+    },
+    "with a malformed YAML file": {
+      topic: function () {
+        var filePath = path.join(__dirname, '..', 'fixtures', 'malformed.yaml');
+        this.store = new nconf.File({ file: filePath, format: require('nconf-yaml') });
+        return null;
+      },
+      "the load() method with a malformed YAML config file": {
+        topic: function () {
+          this.store.load(this.callback.bind(null, null));
+        },
+        "should respond with an error and indicate file name": function (_, err) {
+          assert.isTrue(!!err);
+          assert.match(err, /malformed\.yaml/);
+        }
+      }
+    }
+  }
+}).addBatch({
+  "When using the nconf file store": {
+    topic: function () {
+      var tmpPath = path.join(__dirname, '..', 'fixtures', 'tmp.yaml'),
+          tmpStore = new nconf.File({ file: tmpPath, format: require('nconf-yaml') });
+      return tmpStore;
+    },
+    "the save() method": {
+      topic: function (tmpStore) {
+        var that = this;
+
+        Object.keys(data).forEach(function (key) {
+          tmpStore.set(key, data[key]);
+        });
+
+        tmpStore.save(function () {
+          fs.readFile(tmpStore.file, function (err, d) {
+            fs.unlinkSync(tmpStore.file);
+
+            return err
+              ? that.callback(err)
+              : that.callback(err, YAML.safeLoad(d.toString()));
+          });
+        });
+      },
+      "should save the data correctly": function (err, read) {
+        assert.isNull(err);
+        assert.deepEqual(read, data);
+      }
+    }
+  }
+}).addBatch({
+  "When using the nconf file store": {
+    topic: function () {
+      var tmpPath = path.join(__dirname, '..', 'fixtures', 'tmp.yaml'),
+          tmpStore = new nconf.File({ file: tmpPath, format: require('nconf-yaml') });
+      return tmpStore;
+    },
+    "the saveSync() method": {
+      topic: function (tmpStore) {
+        var that = this;
+
+        Object.keys(data).forEach(function (key) {
+          tmpStore.set(key, data[key]);
+        });
+
+        var saved = tmpStore.saveSync();
+
+        fs.readFile(tmpStore.file, function (err, d) {
+          fs.unlinkSync(tmpStore.file);
+
+          return err
+            ? that.callback(err)
+            : that.callback(err, YAML.safeLoad(d.toString()), saved);
+        });
+      },
+      "should save the data correctly": function (err, read, saved) {
+        assert.isNull(err);
+        assert.deepEqual(read, data);
+        assert.deepEqual(read, saved);
+      }
+    }
+  }
+}).export(module);


### PR DESCRIPTION
Ref #123 and #129 

This is some minor changes to how custom formats is handled. The biggest feature is that it can detect the correct format by looking at the file extension.

Also removes the ini format. Users should do:
```js
nconf.formats.ini = require('ini')
```
or
```js
nconf.formats.yaml = require('nconf-yaml')
```