### PR TITLE
fixing async support with nconf-redis

### DIFF
--- a/lib/nconf/provider.js
+++ b/lib/nconf/provider.js
@@ -241,7 +241,9 @@ Provider.prototype.get = function (key, callback) {
           return next(err);
         }
 
-        response = value;
+        if(value){
+          response = value;
+        }
 
         // Merge objects if necessary
         if (typeof response === 'object' && !Array.isArray(response)) {


### PR DESCRIPTION
I spent a while yesterday tracking down a strange bug, I'm not sure if this is an io.js problem or if its something a bit deeper rooted. I was trying to setup a situation where I had a nconf-redis store setup that would take precedence over local "defaults" but I kept getting the following error when I ran it: 
```
stack:
   [ 'TypeError: Cannot convert undefined or null to object',
     '    at Function.keys (native)',
     '    at /Users/mansona/git/blooie/public/nconf/lib/nconf/common.js:108:12',
     '    at Array.forEach (native)',
     '    at Object.common.merge (/Users/mansona/git/blooie/public/nconf/lib/nconf/common.js:107:8)',
     '    at /Users/mansona/git/blooie/public/nconf/lib/nconf/provider.js:269:25',
     '    at Object.async.whilst (/Users/mansona/git/blooie/public/nconf/node_modules/async/lib/async.js:686:13)',
...
```
I tracked it down to the change in this PR that seemed to think that the ```typeof null``` is ```object```. Now i don't know what is wrong here but all I know is that this fix solves the issue for me. I have had issues running tests on nconf-redis (see this issue: https://github.com/indexzero/nconf-redis/issues/10 ) and i'm happy to try and fix this on that end if that is the issue but like i said, this fixes it for me. 

Let me know if you want any more info on what I was trying to do. 