### PR TITLE
Added fileValid method to test if a config file is valid

### DIFF
--- a/lib/nconf/provider.js
+++ b/lib/nconf/provider.js
@@ -64,6 +64,28 @@ Provider.prototype.file = function (key, options) {
 };
 
 //
+// ### function fileValid (path)
+// #### @path {string} Path to file.
+// Verifies if a config file is valid. Accepts the following options
+//
+//    nconf.fileValid('path/to/config/file');
+//
+Provider.prototype.fileValid = function (path) {
+  options = { file: path };
+  options.type = 'file';
+  key = '__nconf_verify__';
+  var valid = true;
+  try {
+    this.add(key, options);
+  } catch(err) {
+    valid = false;
+  } finally {
+    this.remove(key);
+  }
+  return valid;
+};
+
+//
 // Define wrapper functions for using
 // overrides and defaults
 //

--- a/test/provider-test.js
+++ b/test/provider-test.js
@@ -167,4 +167,25 @@ vows.describe('nconf/provider').addBatch({
       }
     }
   }
+}).addBatch({
+  "When using nconf": {
+    "an instance of 'nconf.Provider'": {
+      "the .fileValid() method": {
+        "with an invalid file": {
+          "should respond with false": function () {
+            var file = path.join(__dirname, 'fixtures', 'malformed.json');
+            assert.isFalse(nconf.fileValid(file));
+            assert.isFalse(nconf.stores.hasOwnProperty('__nconf_verify__'));
+          }
+        },
+        "with a valid file": {
+          "should respond with true": function () {
+            var file = path.join(__dirname, 'fixtures', 'complete.json');
+            assert.isTrue(nconf.fileValid(file));
+            assert.isFalse(nconf.stores.hasOwnProperty('__nconf_verify__'));
+          }
+        }
+      }
+    }
+  }
 }).export(module);


### PR DESCRIPTION
I've added a quick fileValid method to test if a given config file is valid. I've also included relevant tests. This makes it easy to check if a file is valid before attempting to load it.
Basically, it tries to add the file as a new store with nconf.add (using a unique name to ensure no conflicts) and catches the error if there is one. Before returning it cleans up by removing the store and returns true if there were no errors or false if there was an error.