### PR TITLE
env({lowerCase:true}) option to make it possible to get() keys in lower case

### DIFF
--- a/lib/nconf/stores/env.js
+++ b/lib/nconf/stores/env.js
@@ -23,6 +23,7 @@ var Env = exports.Env = function (options) {
   this.readOnly  = true;
   this.whitelist = options.whitelist || [];
   this.separator = options.separator || '';
+  this.lowerCase = options.lowerCase || false;
 
   if (typeof options.match === 'function'
       && typeof options !== 'string') {
@@ -56,8 +57,16 @@ Env.prototype.loadSync = function () {
 Env.prototype.loadEnv = function () {
   var self = this;
 
+  var env = process.env;
+
+  if (this.lowerCase) {
+    Object.keys(env).forEach(function (key) {
+      env[key.toLowerCase()] = env[key];
+    });
+  }
+
   this.readOnly = false;
-  Object.keys(process.env).filter(function (key) {
+  Object.keys(env).filter(function (key) {
     if (self.match && self.whitelist.length) {
       return key.match(self.match) || self.whitelist.indexOf(key) !== -1
     }
@@ -69,10 +78,10 @@ Env.prototype.loadEnv = function () {
     }
   }).forEach(function (key) {
     if (self.separator) {
-      self.set(common.key.apply(common, key.split(self.separator)), process.env[key]);
+      self.set(common.key.apply(common, key.split(self.separator)), env[key]);
     }
     else {
-      self.set(key, process.env[key]);
+      self.set(key, env[key]);
     }
   });
 

--- a/test/complete-test.js
+++ b/test/complete-test.js
@@ -123,4 +123,26 @@ vows.describe('nconf/multiple-stores').addBatch({
       nconf.remove('env');
     }
   }
+}).addBatch({
+  // Threw this in it's own batch to make sure it's run separately from the
+  // sync check
+  "When using env with lowerCase:true": {
+    topic: function () {
+      var that = this;
+      helpers.cp(complete, completeTest, function () {
+        nconf.env({ lowerCase: true });
+        that.callback();
+      });
+    },
+    "env vars": {
+      "keys also available as lower case": function () {
+        Object.keys(process.env).forEach(function (key) {
+          assert.equal(nconf.get(key.toLowerCase()), process.env[key]);
+        });
+      }
+    },
+    teardown: function () {
+      nconf.remove('env');
+    }
+  }
 }).export(module);


### PR DESCRIPTION
This will make it possible to pass `lowerCase: true` to env() so that if an environment variable is called `SOMETHING` or `SOMEthing`, it will also be gettable using `something`. This is useful because environment variables are usually capitalised by convention while argv are usually lower case. With this option, one could make all argv options available as capitalized environment variables for example.