### PR TITLE
fix: env.match test

### DIFF
--- a/lib/nconf/stores/env.js
+++ b/lib/nconf/stores/env.js
@@ -24,7 +24,7 @@ var Env = exports.Env = function (options) {
   this.whitelist = options.whitelist || [];
   this.separator = options.separator || '';
 
-  if (typeof options.match === 'function'
+  if (({}).toString.call(options.match) === '[object RegExp]'
       && typeof options !== 'string') {
     this.match = options.match;
   }

--- a/test/complete-test.js
+++ b/test/complete-test.js
@@ -16,12 +16,23 @@ var fs = require('fs'),
 var completeTest = helpers.fixture('complete-test.json'),
     complete = helpers.fixture('complete.json');
 
+// prime the process.env
+process.env['NCONF_foo'] = 'bar';
+process.env.FOO = 'bar';
+process.env.BAR = 'zalgo';
+process.env.NODE_ENV = 'debug';
+process.env.FOOBAR = 'should not load';
+
 vows.describe('nconf/multiple-stores').addBatch({
   "When using the nconf with multiple providers": {
     topic: function () {
       var that = this;
       helpers.cp(complete, completeTest, function () {
-        nconf.env();
+        nconf.env({
+          // separator: '__',
+          match: /^NCONF_/,
+          whitelist: ['NODE_ENV', 'FOO', 'BAR']
+        });
         nconf.file({ file: completeTest });
         nconf.use('argv', { type: 'literal', store: data });
         that.callback();
@@ -34,7 +45,7 @@ vows.describe('nconf/multiple-stores').addBatch({
     },
     "env vars": {
       "are present": function () {
-        Object.keys(process.env).forEach(function (key) {
+        ['NODE_ENV', 'FOO', 'BAR', 'NCONF_foo'].forEach(function (key) {
           assert.equal(nconf.get(key), process.env[key]);
         });
       }


### PR DESCRIPTION
The previous test was expecting the .match value to be a function rather than a regexp which is what the README shows. So I've fixed the code to match against a real regexp, and test if the stringified version of the regexp function is [object RegExp].

I've also updated the tests to prime the process.env with values that are specifically tested for to ensure it's correctly loading the env values.

Fixes #178