### PR TITLE
Don't do index lookups on strings.

### DIFF
--- a/lib/nconf/stores/memory.js
+++ b/lib/nconf/stores/memory.js
@@ -43,7 +43,7 @@ Memory.prototype.get = function (key) {
   //
   while (path.length > 0) {
     key = path.shift();
-    if (target && target.hasOwnProperty(key)) {
+    if (target && typeof target !== 'string' && target.hasOwnProperty(key)) {
       target = target[key];
       continue;
     }

--- a/test/nconf-test.js
+++ b/test/nconf-test.js
@@ -55,6 +55,9 @@ vows.describe('nconf').addBatch({
         "without a callback": {
           "should respond with the correct value": function () {
             assert.equal(nconf.get('foo:bar:bazz'), 'buzz');
+          },
+          "should not step inside strings": function () {
+            assert.equal(nconf.get('foo:bar:bazz:0'), undefined);
           }
         },
         "with a callback": {


### PR DESCRIPTION
`hasOwnProperty(number)` can return true for strings.

This is unlikely to be the desired usage, and can mean that odd
responses are returned by nconf.

Disable trying to check `hasOwnProperty` of strings.

This feels like a bug, rather than expected behaviour? But no stress if you don't agree :-)

(Not sure where the test belongs? :-s Just picked somewhere that seemed logical :-s )

(An example of this is:

```
nconf = require('nconf')
process.env.asd = 'something'
nconf.use('env')
nconf.get('asd:1')
```

We have some dynamically typed fields... (eg a string for simple config, or an object (or array) for more involved config, hence how we hit this issue.)

I understand if you think this is just sloppy typing :-p -- also understand if you'd prefer this to be behind a config option :-)
)
