### PR TITLE
Fix environment variable lowerCase for Windows

### DIFF
--- a/lib/nconf/stores/env.js
+++ b/lib/nconf/stores/env.js
@@ -61,7 +61,9 @@ Env.prototype.loadEnv = function () {
 
   if (this.lowerCase) {
     Object.keys(env).forEach(function (key) {
-      env[key.toLowerCase()] = env[key];
+      var tmp = env[key];
+      delete env[key];
+      env[key.toLowerCase()] = tmp;
     });
   }
 


### PR DESCRIPTION
Windows isn't allow a lowercase name of the environmental variable to be added, if one already exists.  As if that object is somehow case-insensitive.  This works around it by removing the upperCase version.
