### PR TITLE
Add transform function option to env provider

### DIFF
--- a/lib/nconf/stores/env.js
+++ b/lib/nconf/stores/env.js
@@ -24,6 +24,7 @@ var Env = exports.Env = function (options) {
   this.whitelist = options.whitelist || [];
   this.separator = options.separator || '';
   this.lowerCase = options.lowerCase || false;
+  this.transform = options.transform || false;
 
   if (({}).toString.call(options.match) === '[object RegExp]'
       && typeof options !== 'string') {
@@ -62,6 +63,12 @@ Env.prototype.loadEnv = function () {
   if (this.lowerCase) {
     Object.keys(env).forEach(function (key) {
       env[key.toLowerCase()] = env[key];
+    });
+  }
+
+  if (this.transform) {
+    Object.keys(env).forEach(function (key) {
+      env[self.transform(key)] = env[key];
     });
   }
 

--- a/test/complete-test.js
+++ b/test/complete-test.js
@@ -23,6 +23,15 @@ process.env.BAR = 'zalgo';
 process.env.NODE_ENV = 'debug';
 process.env.FOOBAR = 'should not load';
 
+var isFreight = /^[A-Z0-9_]+$/;
+function freightToCamel(str) {
+  if (!isFreight.test(str)) return str;
+  return str.split(/_+/)
+    .filter(function (w) { return !!w; })
+    .map(function (w, i) { return i === 0 ? w.toLowerCase() : w[0].toUpperCase() + w.substr(1).toLowerCase(); })
+    .join('');
+}
+
 vows.describe('nconf/multiple-stores').addBatch({
   "When using the nconf with multiple providers": {
     topic: function () {
@@ -31,7 +40,8 @@ vows.describe('nconf/multiple-stores').addBatch({
         nconf.env({
           // separator: '__',
           match: /^NCONF_/,
-          whitelist: ['NODE_ENV', 'FOO', 'BAR']
+          whitelist: ['NODE_ENV', 'FOO', 'BAR'],
+          transform: freightToCamel
         });
         nconf.file({ file: completeTest });
         nconf.use('argv', { type: 'literal', store: data });
@@ -48,6 +58,9 @@ vows.describe('nconf/multiple-stores').addBatch({
         ['NODE_ENV', 'FOO', 'BAR', 'NCONF_foo'].forEach(function (key) {
           assert.equal(nconf.get(key), process.env[key]);
         });
+      },
+      "are transformed": function () {
+        assert.equal(nconf.get('fooBar'), process.env['FOO_BAR'])
       }
     },
     "json vars": {


### PR DESCRIPTION
This is a very simple change to the **env** provider to allow a `transform` function to be provided for keys, to allow greater control over how they are transformed.

For example, this function could be used to convert FREIGHT_CASE (e.g. `FOO_BAR`) to camelCase (e.g. `fooBar`):

``` javascript
var isFreight = /^[A-Z0-9_]+$/;
function freightToCamel(str) {
  if (!isFreight.test(str)) return str;
  return str.split(/_+/)
    .filter(function (w) { return !!w; })
    .map(function (w, i) { return i === 0 ? w.toLowerCase() : w[0].toUpperCase() + w.substr(1).toLowerCase(); })
    .join('');
}
```
