### PR TITLE
Keep hierarchy when updating store with `use()` function

### DIFF
--- a/lib/nconf/provider.js
+++ b/lib/nconf/provider.js
@@ -102,11 +102,9 @@ Provider.prototype.use = function (name, options) {
   var store = this.stores[name],
       update = store && !sameOptions(store);
 
-  if (!store || update) {
-    if (update) {
-      this.remove(name);
-    }
-
+  if (!store) {
+    this.add(name, options);
+  } else if (store && update) {
     this.add(name, options);
   }
 

--- a/test/provider-test.js
+++ b/test/provider-test.js
@@ -71,7 +71,15 @@ vows.describe('nconf/provider').addBatch({
       "when 'env' is set to true with a nested separator": helpers.assertSystemConf({
         script: path.join(fixturesDir, 'scripts', 'nconf-nested-env.js'),
         env: { SOME_THING: 'foobar' }
-      })
+      }),
+      "calling the use() method after adding other stores": {
+        topic: new nconf.Provider().use('file', { file: files[0] }).defaults({candy: {something: 'should never get this'}}),
+        "should use a new instance of the store type": function (provider) {
+          provider.use('file', { file: files[1] });
+
+          assert.equal(provider.get('candy:something'), 'file2');
+        }
+      },
     }
   }
 }).addBatch({


### PR DESCRIPTION
Previously, when store were updated with `Provider.use()` function it were moved as last in configuration hierarchy. This caused that usually some other configuration were overriding updated configurations and the updates never get applied.
Updated `use()` function to not remove/add the store, instead just "re-set" the store so the store key keep the same position in the `this.stores` hash keys.
Closes #176 
### Example:

file1.json

``` json
{
  "candy": {
    "something": "file1"
  }
}
```

file2.json

``` json
{
  "candy": {
    "something": "file2"
  }
}
```

``` javascript
var nconf = nconf
  .use('file', { file: 'file1.json' })
  .defaults({candy: {something: 'should never get this because read from files'}});

nconf = nconf.use('file', { file: 'file2.json' });

nconf.get('candy:something') == 'file2'
=> false

nconf.get('candy:something')
=> "'should never get this because read from files"
```

> Expect the value be `file2` because the `file` store were updated with `use()`
