### PR TITLE
Add posibility to pass a yargs instance to argv() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,23 @@ Responsible for loading the values parsed from `process.argv` by `yargs` into th
   });
 ```
 
+It's also possible to pass a configured yargs instance
+
+``` js
+  nconf.argv(require('yargs')
+    .version('1.2.3')
+    .usage('My usage definition')
+    .strict()
+    .options({
+      "x": {
+        alias: 'example',
+        describe: 'Example description for usage generation',
+        demand: true,
+        default: 'some-value'
+      }
+    }));
+```
+
 ### Env
 Responsible for loading the values parsed from `process.env` into the configuration hierarchy.
 

--- a/lib/nconf/stores/argv.js
+++ b/lib/nconf/stores/argv.js
@@ -44,9 +44,11 @@ Argv.prototype.loadArgv = function () {
   var self = this,
       yargs, argv;
 
-  yargs = typeof this.options === 'object'
-    ? require('yargs')(process.argv.slice(2)).options(this.options)
-    : require('yargs')(process.argv.slice(2));
+  yargs = isYargs(this.options) ?
+    this.options :
+    typeof this.options === 'object' ?
+      require('yargs')(process.argv.slice(2)).options(this.options) :
+      require('yargs')(process.argv.slice(2));
 
   if (typeof this.usage === 'string') { yargs.usage(this.usage) }
 
@@ -69,3 +71,7 @@ Argv.prototype.loadArgv = function () {
   this.readOnly = true;
   return this.store;
 };
+
+function isYargs(obj) {
+  return (typeof obj === 'function') && ('argv' in obj);
+}


### PR DESCRIPTION
This allows to setup yargs as you desire and still use nconf.argv
