### PR TITLE
[fix] handle buffers 

### DIFF
--- a/lib/nconf/stores/file.js
+++ b/lib/nconf/stores/file.js
@@ -38,8 +38,8 @@ var File = exports.File = function (options) {
     || 2;
 
   if (this.secure) {
-    this.secure = typeof this.secure === 'string'
-      ? { secret: this.secure }
+    this.secure = Buffer.isBuffer(this.secure) || typeof this.secure === 'string'
+      ? { secret: this.secure.toString() }
       : this.secure;
 
     this.secure.alg = this.secure.alg || 'aes-256-ctr';


### PR DESCRIPTION
This prevents ambiguous errors when we do not read the file as `utf8`