### PR TITLE
Copy `process.env` before lower-casing the keys

### DIFF
--- a/lib/nconf/stores/env.js
+++ b/lib/nconf/stores/env.js
@@ -60,8 +60,9 @@ Env.prototype.loadEnv = function () {
   var env = process.env;
 
   if (this.lowerCase) {
-    Object.keys(env).forEach(function (key) {
-      env[key.toLowerCase()] = env[key];
+    env = {};
+    Object.keys(process.env).forEach(function (key) {
+      env[key.toLowerCase()] = process.env[key];
     });
   }
 


### PR DESCRIPTION
`process.env` is read-only in GitBash (and potentially other consoles),
so the `lowerCase` flag had no effect.