### PR TITLE
Remove unintentional 'y' in code block ending.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Removes the store with the specified `name.` The configuration stored at that le
 
 ``` js
   nconf.remove('file');
-```y
+```
 
 ### nconf.required(keys)
 Declares a set of string keys to be mandatory, and throw an error if any are missing.


### PR DESCRIPTION
Was causing a formatting issue: 
![image](https://cloud.githubusercontent.com/assets/706039/14438567/60d3ea62-ffec-11e5-9101-f2bdeaa7d645.png)
