### PR TITLE
Fixed some issues with code escaping in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ Removes the store with the specified `name.` The configuration stored at that le
 
 ``` js
   nconf.remove('file');
-```y
+```
 
 ### nconf.required(keys)
 Declares a set of string keys to be mandatory, and throw an error if any are missing.
 
-```js
+``` js
   nconf.defaults({
     keya: 'a',
   });
@@ -293,7 +293,7 @@ Once installing both `nconf` and `nconf-redis`, you must require both modules to
 ```
 
 ## Installation
-```
+``` bash
   npm install nconf --save
 ```
 


### PR DESCRIPTION
For example, there was an accidental character after a code block making the next piece of text also be formatted as code.