### PR TITLE
fix #130 with proper syntax & on master branch

### DIFF
--- a/lib/nconf.js
+++ b/lib/nconf.js
@@ -5,10 +5,14 @@
  *
  */
 
-var fs = require('fs'),
-    async = require('async'),
+var async = require('async'),
     common = require('./nconf/common'),
-    Provider = require('./nconf/provider').Provider;
+    Provider = require('./nconf/provider').Provider,
+    argv = require('./nconf/stores/argv'),
+    env = require('./nconf/stores/env'),
+    file = require('./nconf/stores/file'),
+    literal = require('./nconf/stores/literal'),
+    memory = require('./nconf/stores/memory');
 
 //
 // `nconf` is by default an instance of `nconf.Provider`.
@@ -21,15 +25,41 @@ var nconf = module.exports = new Provider();
 nconf.version = require('../package.json').version;
 
 //
-// Setup all stores as lazy-loaded getters.
+// Setup all stores as getters
 //
-fs.readdirSync(__dirname + '/nconf/stores').forEach(function (file) {
-  var store = file.replace('.js', ''),
-      name  = common.capitalize(store);
+Object.defineProperty(nconf, 'Argv', {
+  enumerable: true,
+  get: function () {
+    return argv;
+  }
+});
 
-  nconf.__defineGetter__(name, function () {
-    return require('./nconf/stores/' + store)[name];
-  });
+Object.defineProperty(nconf, 'Env', {
+  enumerable: true,
+  get: function () {
+    return env;
+  }
+});
+
+Object.defineProperty(nconf, 'File', {
+  enumerable: true,
+  get: function () {
+    return file;
+  }
+});
+
+Object.defineProperty(nconf, 'Literal', {
+  enumerable: true,
+  get: function () {
+    return literal;
+  }
+});
+
+Object.defineProperty(nconf, 'Memory', {
+  enumerable: true,
+  get: function () {
+    return memory;
+  }
 });
 
 //
@@ -41,4 +71,3 @@ nconf.loadFiles     = common.loadFiles;
 nconf.loadFilesSync = common.loadFilesSync;
 nconf.formats       = require('./nconf/formats');
 nconf.Provider      = Provider;
-

--- a/lib/nconf/common.js
+++ b/lib/nconf/common.js
@@ -8,7 +8,7 @@
 var fs = require('fs'),
     async = require('async'),
     formats = require('./formats'),
-    Memory = require('./stores/memory').Memory;
+    Memory = require('./stores/memory');
 
 var common = exports;
 
@@ -62,9 +62,9 @@ common.loadFiles = function (files, callback) {
 
   function parseFile (file, next) {
     fs.readFile(file, function (err, data) {
-      return !err
-        ? next(null, options.format.parse(data.toString()))
-        : next(err);
+      return !err ?
+        next(null, options.format.parse(data.toString())) :
+        next(err);
     });
   }
 

--- a/lib/nconf/formats.js
+++ b/lib/nconf/formats.js
@@ -15,7 +15,7 @@ var formats = exports;
 //
 formats.json = {
   stringify: function (obj, replacer, spacing) {
-    return JSON.stringify(obj, replacer || null, spacing || 2)
+    return JSON.stringify(obj, replacer || null, spacing || 2);
   },
   parse: JSON.parse
 };

--- a/lib/nconf/provider.js
+++ b/lib/nconf/provider.js
@@ -54,9 +54,9 @@ Provider.prototype.file = function (key, options) {
     key = 'file';
   }
   else {
-    options = typeof options === 'string'
-      ? { file: options }
-      : options;
+    options = typeof options === 'string' ?
+      { file: options } :
+      options;
   }
 
   options.type = 'file';
@@ -357,7 +357,7 @@ Provider.prototype.merge = function () {
       return onError(new Error('Cannot merge non-Object into top-level.'), callback);
     }
 
-    return async.forEach(Object.keys(value), mergeProperty, callback || function () { })
+    return async.forEach(Object.keys(value), mergeProperty, callback || function () { });
   }
 
   return this._execute('merge', 2, key, value, callback);
@@ -392,8 +392,8 @@ Provider.prototype.load = function (callback) {
       return next(new Error('nconf store ' + store.type + ' has no load() method'));
     }
 
-    return store.loadSync
-      ? next(null, store.loadSync())
+    return store.loadSync ?
+      next(null, store.loadSync())
       : store.load(next);
   }
 
@@ -444,8 +444,8 @@ Provider.prototype.load = function (callback) {
     });
   }
 
-  return self.sources.length
-    ? loadSources()
+  return self.sources.length ?
+    loadSources()
     : loadBatch(getStores(), callback);
 };
 
@@ -551,8 +551,8 @@ Provider.prototype._execute = function (action, syncLength /* [arguments] */) {
       return next();
     }
 
-    return store[action].length > syncLength
-      ? store[action].apply(store, args.concat(next))
+    return store[action].length > syncLength ?
+      store[action].apply(store, args.concat(next))
       : next(null, store[action].apply(store, args));
   }
 
@@ -585,7 +585,7 @@ Provider.prototype._execute = function (action, syncLength /* [arguments] */) {
   }
 
   return response;
-}
+};
 
 //
 // Throw the `err` if a callback is not supplied

--- a/lib/nconf/stores/argv.js
+++ b/lib/nconf/stores/argv.js
@@ -6,7 +6,7 @@
  */
 
 var util = require('util'),
-    Memory = require('./memory').Memory;
+    Memory = require('./memory');
 
 //
 // ### function Argv (options)
@@ -14,7 +14,7 @@ var util = require('util'),
 // Constructor function for the Argv nconf store, a simple abstraction
 // around the Memory store that can read command-line arguments.
 //
-var Argv = exports.Argv = function (options, usage) {
+var Argv = module.exports = function (options, usage) {
   Memory.call(this, options);
 
   this.type     = 'argv';
@@ -44,13 +44,13 @@ Argv.prototype.loadArgv = function () {
   var self = this,
       yargs, argv;
 
-  yargs = typeof this.options === 'object'
-    ? require('yargs')(process.argv.slice(2)).options(this.options)
-    : require('yargs')(process.argv.slice(2));
+  yargs = typeof this.options === 'object' ?
+    require('yargs')(process.argv.slice(2)).options(this.options) :
+    require('yargs')(process.argv.slice(2));
 
-  if (typeof this.usage === 'string') { yargs.usage(this.usage) }
+  if (typeof this.usage === 'string') { yargs.usage(this.usage); }
 
-  argv = yargs.argv
+  argv = yargs.argv;
 
   if (!argv) {
     return;
@@ -63,8 +63,8 @@ Argv.prototype.loadArgv = function () {
     }
   });
 
-  this.showHelp = yargs.showHelp
-  this.help     = yargs.help
+  this.showHelp = yargs.showHelp;
+  this.help     = yargs.help;
 
   this.readOnly = true;
   return this.store;

--- a/lib/nconf/stores/env.js
+++ b/lib/nconf/stores/env.js
@@ -7,7 +7,7 @@
 
 var util = require('util'),
     common = require('../common'),
-    Memory = require('./memory').Memory;
+    Memory = require('./memory');
 
 //
 // ### function Env (options)
@@ -15,7 +15,7 @@ var util = require('util'),
 // Constructor function for the Env nconf store, a simple abstraction
 // around the Memory store that can read process environment variables.
 //
-var Env = exports.Env = function (options) {
+var Env = module.exports = function (options) {
   Memory.call(this, options);
 
   options        = options || {};
@@ -25,8 +25,8 @@ var Env = exports.Env = function (options) {
   this.separator = options.separator || '';
   this.lowerCase = options.lowerCase || false;
 
-  if (({}).toString.call(options.match) === '[object RegExp]'
-      && typeof options !== 'string') {
+  if (({}).toString.call(options.match) === '[object RegExp]' &&
+      typeof options !== 'string') {
     this.match = options.match;
   }
 
@@ -68,13 +68,13 @@ Env.prototype.loadEnv = function () {
   this.readOnly = false;
   Object.keys(env).filter(function (key) {
     if (self.match && self.whitelist.length) {
-      return key.match(self.match) || self.whitelist.indexOf(key) !== -1
+      return key.match(self.match) || self.whitelist.indexOf(key) !== -1;
     }
     else if (self.match) {
       return key.match(self.match);
     }
     else {
-      return !self.whitelist.length || self.whitelist.indexOf(key) !== -1
+      return !self.whitelist.length || self.whitelist.indexOf(key) !== -1;
     }
   }).forEach(function (key) {
     if (self.separator) {
@@ -88,4 +88,3 @@ Env.prototype.loadEnv = function () {
   this.readOnly = true;
   return this.store;
 };
-

--- a/lib/nconf/stores/file.js
+++ b/lib/nconf/stores/file.js
@@ -11,7 +11,7 @@ var crypto = require('crypto'),
     util = require('util'),
     Secure = require('secure-keys'),
     formats = require('../formats'),
-    Memory = require('./memory').Memory,
+    Memory = require('./memory'),
     exists = fs.exists || path.exists,
     existsSync = fs.existsSync || path.existsSync;
 
@@ -21,7 +21,7 @@ var crypto = require('crypto'),
 // Constructor function for the File nconf store, a simple abstraction
 // around the Memory store that can persist configuration to disk.
 //
-var File = exports.File = function (options) {
+var File = module.exports = function (options) {
   if (!options || !options.file) {
     throw new Error ('Missing required option `file`');
   }
@@ -33,14 +33,13 @@ var File = exports.File = function (options) {
   this.dir     = options.dir    || process.cwd();
   this.format  = options.format || formats.json;
   this.secure  = options.secure;
-  this.spacing = options.json_spacing
-    || options.spacing
-    || 2;
+  this.spacing = options.json_spacing || options.spacing || 2;
 
   if (this.secure) {
-    this.secure = Buffer.isBuffer(this.secure) || typeof this.secure === 'string'
-      ? { secret: this.secure.toString() }
-      : this.secure;
+    this.secure = Buffer.isBuffer(this.secure) ||
+      typeof this.secure === 'string' ?
+        { secret: this.secure.toString() } :
+        this.secure;
 
     this.secure.alg = this.secure.alg || 'aes-256-ctr';
     if (this.secure.secretPath) {

--- a/lib/nconf/stores/literal.js
+++ b/lib/nconf/stores/literal.js
@@ -6,12 +6,12 @@
  */
 
 var util = require('util'),
-    Memory = require('./memory').Memory
+    Memory = require('./memory');
 
-var Literal = exports.Literal = function Literal (options) {
+var Literal = module.exports = function Literal (options) {
   Memory.call(this, options);
 
-  options       = options || {}
+  options       = options || {};
   this.type     = 'literal';
   this.readOnly = true;
   this.store    = options.store || options;

--- a/lib/nconf/stores/memory.js
+++ b/lib/nconf/stores/memory.js
@@ -15,7 +15,7 @@ var common = require('../common');
 //
 // e.g. `my:nested:key` ==> `{ my: { nested: { key: } } }`
 //
-var Memory = exports.Memory = function (options) {
+var Memory = module.exports = function (options) {
   options       = options || {};
   this.type     = 'memory';
   this.store    = {};

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "nconf",
+  "name": "kevoree-nconf",
   "description": "Hierarchical node.js configuration with files, environment variables, command-line arguments, and atomic object merging.",
   "version": "0.8.4",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "http://github.com/flatiron/nconf.git"
+    "url": "http://github.com/maxleiko/nconf.git"
   },
   "keywords": [
     "configuration",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kevoree-nconf",
   "description": "Hierarchical node.js configuration with files, environment variables, command-line arguments, and atomic object merging.",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi there,

I've fixed #130 as you did in [this commit](https://github.com/indexzero/nconf/commit/d501e7b04ce0c04b950f94ca8b7d31d26e50fc61) but using `Object.defineProperty` instead of `__defineGetter__`.  
Also, you've fixed it in branch `gh` and did not publish any `nconf` version on the npm registry with this patch. Do you plan to merge this PR and publish `nconf` in a near future?
