### PR TITLE
Whitelist npm published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cover": "istanbul cover vows -- test/*-test.js test/**/*-test.js  --spec",
     "coveralls": "cat coverage/lcov.info | coveralls"
   },
+  "files": ["lib"],
   "engines": {
     "node": ">= 0.4.0"
   },


### PR DESCRIPTION
- reduces files published to npm and downloaded with every install

This prevents unnecessary files & folders (`test`, `usage.js`, `.travis.yml`, etc) from being published to NPM.
