### PR TITLE
Add support for loading and saving js files.

### DIFF
--- a/lib/nconf/formats.js
+++ b/lib/nconf/formats.js
@@ -6,6 +6,8 @@
  */
 
 var ini = require('ini');
+var vm = require('vm');
+var util = require('util');
 
 var formats = exports;
 
@@ -26,3 +28,29 @@ formats.json = {
 // http://en.wikipedia.org/wiki/INI_file
 //
 formats.ini = ini;
+
+//
+// ### @js
+// Javascript file in CommonJS module format
+//
+formats.js = {
+  stringify: function (obj, replacer, spacing) {
+    var space = '',
+      numSpace = (spacing || 2);
+    for (var i=0; i < numSpace; i++) {
+        space = space + ' ';
+    }
+    var prefix = 'module.exports' + space + '=' + space;
+    var jsonStr = JSON.stringify(obj, replacer || null , numSpace);
+    return prefix + jsonStr + ';';
+  },
+  parse: function (text) {
+    var context = {module: {exports: {}}};
+    vm.runInNewContext(text, context, {
+      lineOffset: 0,
+      displayErrors: true
+    });
+    console.log(util.inspect(context));
+    return context.module.exports;
+  }
+};


### PR DESCRIPTION
Javascript files must be in CommonJS module format, solving #96  

This is just to start the ball rolling. If it is more appropriate to turn this into a separate plugin instead, just let me know!