### PR TITLE
Don't mutate process.env when load env variables

### DIFF
--- a/lib/nconf/stores/env.js
+++ b/lib/nconf/stores/env.js
@@ -57,7 +57,7 @@ Env.prototype.loadSync = function () {
 Env.prototype.loadEnv = function () {
   var self = this;
 
-  var env = process.env;
+  var env = Object.assign({}, process.env);
 
   if (this.lowerCase) {
     env = {};


### PR DESCRIPTION
Hi,

lowerCase option are ignored when we need lowercased key from env variable.