### PR TITLE
Passing a custom Yargs to Nconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,23 @@ If the return value is falsey, the entry will be dropped from the store, otherwi
   });
 ```
 
+It's also possible to pass a configured yargs instance
+
+``` js
+  nconf.argv(require('yargs')
+    .version('1.2.3')
+    .usage('My usage definition')
+    .strict()
+    .options({
+      "x": {
+        alias: 'example',
+        describe: 'Example description for usage generation',
+        demand: true,
+        default: 'some-value'
+      }
+    }));
+```
+
 ### Env
 Responsible for loading the values parsed from `process.env` into the configuration hierarchy.
 By default, the env variables values are loaded into the configuration as strings.

--- a/lib/nconf/stores/argv.js
+++ b/lib/nconf/stores/argv.js
@@ -48,9 +48,11 @@ Argv.prototype.loadArgv = function () {
   var self = this,
       yargs, argv;
 
-  yargs = typeof this.options === 'object'
-    ? require('yargs')(process.argv.slice(2)).options(this.options)
-    : require('yargs')(process.argv.slice(2));
+  yargs = isYargs(this.options) ?
+    this.options :
+    typeof this.options === 'object' ?
+      require('yargs')(process.argv.slice(2)).options(this.options) :
+      require('yargs')(process.argv.slice(2));
 
   if (typeof this.usage === 'string') { yargs.usage(this.usage) }
 
@@ -83,3 +85,7 @@ Argv.prototype.loadArgv = function () {
   this.readOnly = true;
   return this.store;
 };
+
+function isYargs(obj) {
+  return (typeof obj === 'function') && ('argv' in obj);
+}

--- a/lib/nconf/stores/argv.js
+++ b/lib/nconf/stores/argv.js
@@ -87,5 +87,5 @@ Argv.prototype.loadArgv = function () {
 };
 
 function isYargs(obj) {
-  return (typeof obj === 'function') && ('argv' in obj);
+  return (typeof obj === 'function' || typeof obj === 'object') && ('argv' in obj);
 }

--- a/test/nconf-argv-test.js
+++ b/test/nconf-argv-test.js
@@ -1,0 +1,25 @@
+/*
+ * file-store-test.js: Tests for the nconf File store.
+ *
+ * (C) 2011, Charlie Robbins and the Contributors.
+ *
+ */
+
+var fs = require('fs'),
+    path = require('path'),
+    vows = require('vows'),
+    assert = require('assert'),
+    nconf = require('../lib/nconf'),
+    yargs = require('yargs')
+
+vows.describe('nconf/argv').addBatch({
+  "When using the nconf": {
+    "with a custom yargs": {
+      topic: function () {
+        fs.readFile(path.join(__dirname, '..', 'package.json'), this.callback);
+      },
+    },
+    "with the default yars": {
+    }
+  }
+}).export(module);

--- a/test/stores/argv-test.js
+++ b/test/stores/argv-test.js
@@ -21,7 +21,6 @@ vows.describe('nconf/stores/argv').addBatch({
     "can be created with a custom yargs":{
       topic: function(){
         var yargsInstance = yargs.alias('v', 'verbose').default('v', 'false');
-        console.log(yargsInstance)
         return [yargsInstance, new nconf.Argv(yargsInstance)];
       },
       "and can give access to them": function (argv) {
@@ -31,6 +30,20 @@ vows.describe('nconf/stores/argv').addBatch({
       },
       "values are the one from the custom yargv": function (argv) {
         argv = argv[1]
+        argv.loadSync()
+        assert.equal(argv.get('verbose'), 'false');
+        assert.equal(argv.get('v'), 'false');
+      }
+    },
+    "can be created with a nconf yargs":{
+      topic: function(){
+        var options = {verbose: {alias: 'v', default: 'false'}};
+        return  new nconf.Argv(options);
+      },
+      "and can give access to them": function (argv) {
+        assert.deepEqual(argv.options, {verbose: {alias: 'v', default: 'false'}})
+      },
+      "values are the one from the custom yargv": function (argv) {
         argv.loadSync()
         assert.equal(argv.get('verbose'), 'false');
         assert.equal(argv.get('v'), 'false');

--- a/test/stores/argv-test.js
+++ b/test/stores/argv-test.js
@@ -7,6 +7,7 @@
 
 var vows = require('vows'),
     assert = require('assert'),
+    yargs = require('yargs')
     nconf = require('../../lib/nconf');
 
 vows.describe('nconf/stores/argv').addBatch({
@@ -16,6 +17,24 @@ vows.describe('nconf/stores/argv').addBatch({
       assert.isFunction(argv.loadSync);
       assert.isFunction(argv.loadArgv);
       assert.deepEqual(argv.options, {});
+    },
+    "can be created with a custom yargs":{
+      topic: function(){
+        var yargsInstance = yargs.alias('v', 'verbose').default('v', 'false');
+        console.log(yargsInstance)
+        return [yargsInstance, new nconf.Argv(yargsInstance)];
+      },
+      "and can give access to them": function (argv) {
+        var yargsInstance = argv[0];
+        argv = argv[1]
+        assert.equal(argv.options, yargsInstance)
+      },
+      "values are the one from the custom yargv": function (argv) {
+        argv = argv[1]
+        argv.loadSync()
+        assert.equal(argv.get('verbose'), 'false');
+        assert.equal(argv.get('v'), 'false');
+      }
     }
   }
 }).export(module);


### PR DESCRIPTION
Add posibility to pass a yargs instance to argv() method

Follow up on #202 with tests