### PR TITLE
Transformer can now return an undefined key

### DIFF
--- a/lib/nconf/common.js
+++ b/lib/nconf/common.js
@@ -154,7 +154,7 @@ common.transform = function(map, fn) {
 
     if (!result) {
       return null;
-    } else if (result.key && typeof result.value !== 'undefined') {
+    } else if (result.key) {
       return result;
     }
 

--- a/test/complete-test.js
+++ b/test/complete-test.js
@@ -245,6 +245,34 @@ vows.describe('nconf/multiple-stores').addBatch({
 }).addBatch({
   // Threw this in it's own batch to make sure it's run separately from the
   // sync check
+  "When using env with a transform:fn that return an undefined value": {
+    topic: function () {
+
+      function testTransform(obj) {
+        if (obj.key === 'FOO') {
+          return {key: 'FOO', value: undefined};
+        }
+
+        return obj;
+      }
+
+      var that = this;
+      helpers.cp(complete, completeTest, function () {
+        nconf.env({ transform: testTransform });
+        that.callback();
+      });
+    }, "env vars": {
+      "port key/value properly transformed": function() {
+        assert.equal(typeof nconf.get('FOO'), 'undefined');
+      }
+    }
+  },
+  teardown: function () {
+    nconf.remove('env');
+  }
+}).addBatch({
+  // Threw this in it's own batch to make sure it's run separately from the
+  // sync check
   "When using env with a bad transform:fn": {
     topic: function () {
       function testTransform() {


### PR DESCRIPTION
Currently transformer can now return an undefined key.

Thats an issue with argv that define undefined value for defined keys, especially when you create a transformer that only operate on key. Without this modification you are forced to check what the value is otherwise you get an error `Transform function passed to store returned an invalid format` 