### PR TITLE
Clean Argv Store options

### DIFF
--- a/lib/nconf/stores/argv.js
+++ b/lib/nconf/stores/argv.js
@@ -23,8 +23,19 @@ var Argv = exports.Argv = function (options, usage) {
   this.readOnly = true;
   this.options  = options;
   this.usage    = usage;
-  this.parseValues = options.parseValues || false;
-  this.transform = options.transform || false;
+  if(typeof options.parseValues === 'boolean') {
+      this.parseValues = options.parseValues;
+      options.parseValues = undefined;
+  } else {
+      this.parseValues = false;
+  }
+  if (typeof options.transform === 'function') {
+      this.transform = options.transform;
+      options.transform = undefined;
+  } else {
+      this.transform = false;
+  }
+
 };
 
 // Inherit from the Memory store

--- a/lib/nconf/stores/argv.js
+++ b/lib/nconf/stores/argv.js
@@ -25,13 +25,13 @@ var Argv = exports.Argv = function (options, usage) {
   this.usage    = usage;
   if(typeof options.parseValues === 'boolean') {
       this.parseValues = options.parseValues;
-      options.parseValues = undefined;
+      delete options.parseValues;
   } else {
       this.parseValues = false;
   }
   if (typeof options.transform === 'function') {
       this.transform = options.transform;
-      options.transform = undefined;
+      delete options.transform;
   } else {
       this.transform = false;
   }


### PR DESCRIPTION
> unset parse/transform from options and ensure they are not yargs options

Currently options for the argv store are embedded in the options that are feed to yargs.options.
This PR prevent that, and ensure we are not considering a yargs `parseValues`, `transform`config object as an argv store option. (unlikely but still)