### PR TITLE
Fix insecure use of AES-256-CTR cipher (#296)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ test/fixtures/*.json
 !test/fixtures/bom.json
 !test/fixtures/no-bom.json
 !test/fixtures/secure.json
+!test/fixtures/insecure.json
 node_modules/
 node_modules/*
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -392,21 +392,20 @@ nconf.file('secure-file', {
   file: 'path/to/secure-file.json',
   secure: {
     secret: 'super-secretzzz-keyzz',
-    alg: 'aes-256-ctr'
   }
 })
 ```
 
-This will encrypt each key using [`crypto.createCipher`](https://nodejs.org/api/crypto.html#crypto_crypto_createcipher_algorithm_password), defaulting to `aes-256-ctr`. The encrypted file contents will look like this:
+This will encrypt each key using [`crypto.createCipher`](https://nodejs.org/api/crypto.html#crypto_crypto_createcipher_algorithm_password) using `aes-256-cbc`. The encrypted file contents will look like this:
 
 ```
 {
   "config-key-name": {
-    "alg": "aes-256-ctr", // cipher used
+    "alg": "aes-256-cbc", // cipher used
     "value": "af07fbcf"   // encrypted contents
   },
   "another-config-key": {
-    "alg": "aes-256-ctr",   // cipher used
+    "alg": "aes-256-cbc",   // cipher used
     "value": "e310f6d94f13" // encrypted contents
   },
 }

--- a/lib/nconf/stores/file.js
+++ b/lib/nconf/stores/file.js
@@ -8,7 +8,7 @@
 var fs = require('fs'),
     path = require('path'),
     util = require('util'),
-    Secure = require('secure-keys'),
+    crypto = require('crypto'),
     formats = require('../formats'),
     Memory = require('./memory').Memory;
 
@@ -42,7 +42,6 @@ var File = exports.File = function (options) {
       ? { secret: this.secure.toString() }
       : this.secure;
 
-    this.secure.alg = this.secure.alg || 'aes-256-ctr';
     if (this.secure.secretPath) {
       this.secure.secret = fs.readFileSync(this.secure.secretPath, 'utf8');
     }
@@ -50,12 +49,6 @@ var File = exports.File = function (options) {
     if (!this.secure.secret) {
       throw new Error('secure.secret option is required');
     }
-
-    this.keys = new Secure({
-      secret: this.secure.secret,
-      alg: this.secure.alg,
-      format: this.format
-    });
   }
 
   if (options.search) {
@@ -185,7 +178,15 @@ File.prototype.stringify = function (format) {
   }
 
   if (this.secure) {
-    data = this.keys.encrypt(data);
+    var self = this;
+    data = Object.keys(data).reduce(function (acc, key) {
+      var value = format.stringify(data[key]);
+      var cipher = crypto.createCipher('aes-256-cbc', self.secure.secret);
+      var ciphertext = cipher.update(value, 'utf8', 'hex');
+      ciphertext += cipher.final('hex');
+      acc[key] = { alg: 'aes-256-cbc', value: ciphertext };
+      return acc;
+    }, {});
   }
 
   return format.stringify(data, null, this.spacing);
@@ -199,12 +200,19 @@ File.prototype.stringify = function (format) {
 File.prototype.parse = function (contents) {
   var parsed = this.format.parse(contents);
 
-  if (!this.secure) {
-    return parsed;
+  if (this.secure) {
+    var self = this;
+    parsed = Object.keys(parsed).reduce(function (acc, key) {
+      var value = parsed[key];
+      var decipher = crypto.createDecipher(value.alg, self.secure.secret);
+      var plaintext = decipher.update(value.value, 'hex', 'utf8');
+      plaintext += decipher.final('utf8');
+      acc[key] = self.format.parse(plaintext);
+      return acc;
+    }, {});
   }
 
-  return this.keys.decrypt(parsed);
-
+  return parsed;
 };
 
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "async": "^2.3.0",
     "ini": "^1.3.0",
-    "secure-keys": "^1.0.0",
     "yargs": "^10.0.3"
   },
   "devDependencies": {

--- a/test/fixtures/insecure.json
+++ b/test/fixtures/insecure.json
@@ -1,0 +1,18 @@
+{
+  "isNull": {
+    "alg": "aes-256-ctr",
+    "value": "af07fbcf"
+  },
+  "literal": {
+    "alg": "aes-256-ctr",
+    "value": "e310f6d94f13"
+  },
+  "arr": {
+    "alg": "aes-256-ctr",
+    "value": "9a78b783175e69bb8f3458042b1c098d8ed9613410fac185b3735099224f8fe4ece0f0da8decfddbbf0eab3b7c391c47772b5441"
+  },
+  "obj": {
+    "alg": "aes-256-ctr",
+    "value": "ba78b783175968add93a680429424ae4cf957d2916ebcfa399730bb17200ddb0ecacb183c1b1ebcd950ced76726964062e74643c995c47372bfb1311bee8f65bbeb5a1d9426537a6d83635220ec7934e1d7cc187f7218cd4afadfa2f107fb42c232d80d95c160ee704fa8e922998b0b3e47ec579dd0baef7cae6d7dbaa203d732adb5cff22b80d810d7191237999cd8dc528d8f2201ae128a9f9e2df96d1a816aa73e3e6b8e6246cd98b454e453b36f43f9117cb4af8fa85429a92"
+  }
+}

--- a/test/fixtures/secure.json
+++ b/test/fixtures/secure.json
@@ -1,18 +1,15 @@
 {
   "isNull": {
-    "alg": "aes-256-ctr",
-    "value": "af07fbcf"
-  },
+    "alg": "aes-256-cbc",
+    "value": "7a3deb2e8b22ca554a99b6527b2a5426" },
   "literal": {
-    "alg": "aes-256-ctr",
-    "value": "e310f6d94f13"
-  },
+    "alg": "aes-256-cbc",
+    "value": "4f11de5c83352c0cd59f690dbb9b1aab" },
   "arr": {
-    "alg": "aes-256-ctr",
-    "value": "9a78b783175e69bb8f3458042b1c098d8ed9613410fac185b3735099224f8fe4ece0f0da8decfddbbf0eab3b7c391c47772b5441"
-  },
+    "alg": "aes-256-cbc",
+    "value": "b6430be049eb5997a4d1593d22132bda1785b082037c582004c108af9ed19b8e9a6db435849fe6e7fc590fd10ee3adbdfcc4cef4de1d5478052d90b212ef56f7" },
   "obj": {
-    "alg": "aes-256-ctr",
-    "value": "ba78b783175968add93a680429424ae4cf957d2916ebcfa399730bb17200ddb0ecacb183c1b1ebcd950ced76726964062e74643c995c47372bfb1311bee8f65bbeb5a1d9426537a6d83635220ec7934e1d7cc187f7218cd4afadfa2f107fb42c232d80d95c160ee704fa8e922998b0b3e47ec579dd0baef7cae6d7dbaa203d732adb5cff22b80d810d7191237999cd8dc528d8f2201ae128a9f9e2df96d1a816aa73e3e6b8e6246cd98b454e453b36f43f9117cb4af8fa85429a92"
+    "alg": "aes-256-cbc",
+    "value": "5ed7e01edc6fd8fd79cc7d5899d28ad0e7cce7ae0a2f7d0fcbc6b397dd71c31c900ca0c20b360cb09d58f7792c0b853a94d9511b0fa5b074cbd11d4bbdaa41fd3cf62adc0fcd46e8db18f4aac5b255fbdcf3ba870fe061f8785d387e05bf9a23777c8ab6eb6cf3f2001e83d3668a7408f2aca798208928dd1ff2b7f5e5ad8caa36009e5ba66532d2fcdebd0cd225804845bdcbb217c0bf1c62630517c277dc85513e91a3723c6240f2638832124acdcda5a80ac8253c57ee52d948a138f98592"
   }
 }

--- a/test/stores/file-store-test.js
+++ b/test/stores/file-store-test.js
@@ -306,5 +306,41 @@ vows.describe('nconf/stores/file').addBatch({
       assert.deepEqual(loaded, data);
     }
   }
+}).addBatch({
+  "When using a legacy nconf file store": {
+    topic: function () {
+      var secureStore = new nconf.File({
+        file: path.join(__dirname, '..', 'fixtures', 'insecure.json'),
+        secure: 'super-secretzzz'
+      });
+
+      secureStore.store = data;
+      return secureStore;
+    },
+    "the stringify() method should encrypt properly": function (store) {
+      var contents = JSON.parse(store.stringify());
+      Object.keys(data).forEach(function (key) {
+        assert.isObject(contents[key]);
+        assert.isString(contents[key].value);
+        // Note: accept insecure aes-256-ctr entries but don't write them.
+        assert.equal(contents[key].alg, 'aes-256-cbc');
+      });
+    },
+    "the parse() method should decrypt properly": function (store) {
+      var contents = store.stringify();
+      var parsed = store.parse(contents);
+      assert.deepEqual(parsed, data);
+    },
+    "the load() method should decrypt properly": function (store) {
+      store.load(function (err, loaded) {
+        assert.isNull(err);
+        assert.deepEqual(loaded, data);
+      });
+    },
+    "the loadSync() method should decrypt properly": function (store) {
+      var loaded = store.loadSync()
+      assert.deepEqual(loaded, data);
+    }
+  }
 }).export(module);
 

--- a/test/stores/file-store-test.js
+++ b/test/stores/file-store-test.js
@@ -287,7 +287,7 @@ vows.describe('nconf/stores/file').addBatch({
       Object.keys(data).forEach(function (key) {
         assert.isObject(contents[key]);
         assert.isString(contents[key].value);
-        assert.equal(contents[key].alg, 'aes-256-ctr');
+        assert.equal(contents[key].alg, 'aes-256-cbc');
       });
     },
     "the parse() method should decrypt properly": function (store) {


### PR DESCRIPTION
Using the same IV twice with a counter mode cipher breaks the security
of the cipher.  Switch to AES-256-CBC.

I made the cipher nonconfigurable because it seems more likely than not
that people will get it wrong otherwise.

This commit also drops the dependency on the secure-keys module, which
appears to be unmaintained and didn't really live up to its name.