### PR TITLE
Fix: honor logicalSeparator for env and argv stores

### DIFF
--- a/lib/nconf.js
+++ b/lib/nconf.js
@@ -32,7 +32,6 @@ nconf.version = require('../package.json').version;
 //
 // Expose the various components included with nconf
 //
-nconf.key           = common.key;
 nconf.path          = common.path;
 nconf.loadFiles     = common.loadFiles;
 nconf.loadFilesSync = common.loadFilesSync;

--- a/lib/nconf/common.js
+++ b/lib/nconf/common.js
@@ -26,14 +26,6 @@ common.path = function (key, separator) {
 
 //
 // ### function key (arguments)
-// Returns a `:` joined string from the `arguments`.
-//
-common.key = function () {
-  return Array.prototype.slice.call(arguments).join(':');
-};
-
-//
-// ### function key (arguments)
 // Returns a joined string from the `arguments`,
 // first argument is the join delimiter.
 //

--- a/lib/nconf/stores/argv.js
+++ b/lib/nconf/stores/argv.js
@@ -105,7 +105,7 @@ Argv.prototype.loadArgv = function () {
       }
 
       if (self.separator) {
-        self.set(common.key.apply(common, key.split(self.separator)), val);
+        self.set(common.keyed.apply(common, [self.logicalSeparator].concat(key.split(self.separator))), val);
       }
       else {
         self.set(key, val);

--- a/lib/nconf/stores/env.js
+++ b/lib/nconf/stores/env.js
@@ -98,7 +98,7 @@ Env.prototype.loadEnv = function () {
     }
 
     if (self.separator) {
-      self.set(common.key.apply(common, key.split(self.separator)), val);
+      self.set(common.keyed.apply(common, [self.logicalSeparator].concat(key.split(self.separator))), val);
     }
     else {
       self.set(key, val);

--- a/test/hierarchy-test.js
+++ b/test/hierarchy-test.js
@@ -130,7 +130,6 @@ vows.describe('nconf/hierarchy').addBatch({
               });
           },
           "should merge nested objects ": function (err, data) {
-            console.log(data)
               assert.deepEqual(JSON.parse(data), {
                   apples: true,
                   candy: {

--- a/test/nconf-test.js
+++ b/test/nconf-test.js
@@ -14,7 +14,6 @@ var fs = require('fs'),
 vows.describe('nconf').addBatch({
   "When using the nconf": {
     "should have the correct methods set": function () {
-      assert.isFunction(nconf.key);
       assert.isFunction(nconf.path);
       assert.isFunction(nconf.use);
       assert.isFunction(nconf.any);

--- a/test/stores/argv-test.js
+++ b/test/stores/argv-test.js
@@ -56,7 +56,7 @@ vows.describe('nconf/stores/argv').addBatch({
     "can be created with readOnly set to be false":{
       topic: function(){
         var options = {verbose: {alias: 'v', default: 'false'}, readOnly: false};
-        return  new nconf.Argv(options);
+        return new nconf.Argv(options);
       },
       "readOnly is actually false": function (argv) {
         assert.equal(argv.readOnly, false);

--- a/test/stores/env-test.js
+++ b/test/stores/env-test.js
@@ -10,6 +10,7 @@ var vows = require('vows'),
     nconf = require('../../lib/nconf');
 
 process.env.TES = 'TING';
+process.env.SEPARATED__VALUE = 'FOO';
 
 vows.describe('nconf/stores/env').addBatch({
   "An instance of nconf.Env": {
@@ -31,5 +32,15 @@ vows.describe('nconf/stores/env').addBatch({
       assert.lengthOf(env.whitelist, 0);
       assert.ok(!env.readOnly);
     }
+},
+"An instance of nconf.Env with logicalSeparator option overridden": {
+  topic: new nconf.Env({logicalSeparator: '.', separator: '__'}),
+  "should be able to retrieve a value using the logical separator": function (env) {
+    env.loadEnv();
+    assert.isFunction(env.loadSync);
+    assert.isFunction(env.loadEnv);
+    assert.equal(env.logicalSeparator, '.');
+    assert.equal(env.get('SEPARATED.VALUE'), 'FOO');
+  }
 }
 }).export(module);


### PR DESCRIPTION
Fixes #302.

Also, removes `nconf.key` since it's now useless.