### PR TITLE
[fix] Remove hardcoded /tmp/ directory reference so that saveToFile tests run on Windows. indexzero#325

### DIFF
--- a/test/stores/file-store.test.js
+++ b/test/stores/file-store.test.js
@@ -97,7 +97,7 @@ describe('nconf/stores/file', () => {
     });
     it("the saveToFile() method should save the data correctly", done => {
       var tmpStore = new nconf.File({file: tmpPath});
-      var pathFile = '/tmp/nconf-save-toFile.json';
+      var pathFile = path.join(__dirname, '..', 'fixtures', 'tmp-save-tofile.json');
 
       Object.keys(data).forEach(function (key) {
         tmpStore.set(key, data[key]);
@@ -116,7 +116,7 @@ describe('nconf/stores/file', () => {
     });
     it("the saveToFile() method with custom format should save the data correctly", done => {
       var tmpStore = new nconf.File({file: tmpPath});
-      var pathFile = '/tmp/nconf-save-toFile.yaml';
+      var pathFile = path.join(__dirname, '..', 'fixtures', 'tmp-save-tofile.yaml');
 
       Object.keys(data).forEach(function (key) {
         tmpStore.set(key, data[key]);


### PR DESCRIPTION
Fixes #325 

Changed temp file path from /tmp/ to relative test fixtures directory. Some of the other save unit tests use that location, so this brings everything in line and fixes the unit tests on Windows. 