### PR TITLE
chore: remove support for Node 8.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,6 @@ commands:
       - run:
           command: npm run coveralls
 jobs:
-  node-v8:
-    docker:
-      - image: node:8
-    steps:
-      - test-nodejs
   node-v10:
     docker:
       - image: node:10
@@ -47,11 +42,16 @@ jobs:
       - image: node:12
     steps:
       - test-nodejs
+  node-v14:
+    docker:
+      - image: node:14
+    steps:
+      - test-nodejs
 
 workflows:
   version: 2
   node-multi-build:
     jobs:
-      - node-v8
       - node-v10
       - node-v12
+      - node-v14


### PR DESCRIPTION
Removes support for Node.js v8.x and below, due to dependencies also removing support (and Node 8.x being out of support since Jan 2020).