### PR TITLE
Updated dependecy yargs from 16.0.0 to 16.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6132,9 +6132,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.1.1.tgz",
-      "integrity": "sha512-hAD1RcFP/wfgfxgMVswPE+z3tlPFtxG8/yWUrG2i17sTWGCGqWnxKcLTF4cUKDUK8fzokwsmO9H0TDkRbMHy8w==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "ini": "^1.3.0",
-    "yargs": "^16.0.0"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "async": "^2.6.1",


### PR DESCRIPTION
Dependency update to address [CVE-2020-1774](https://nvd.nist.gov/vuln/detail/CVE-2020-7774)

I've attached a run of the tests. Is setting up a GH action for the tests something this repo would be interested in?

<img width="611" alt="Screen Shot 2020-12-08 at 12 17 40 PM" src="https://user-images.githubusercontent.com/12589078/101518543-0d67b780-3950-11eb-83fa-3ef67c613953.png">