### PR TITLE
Handle case where parsed config object hasn't prototype

### DIFF
--- a/lib/nconf/stores/memory.js
+++ b/lib/nconf/stores/memory.js
@@ -75,7 +75,7 @@ Memory.prototype.get = function (key) {
   //
   while (path.length > 0) {
     key = path.shift();
-    if (target && typeof target !== 'string' && target.hasOwnProperty(key)) {
+    if (target && typeof target !== 'string' && Object.hasOwnProperty.call(target, key)) {
       target = target[key];
       continue;
     }


### PR DESCRIPTION
Config objects read with `ini` library 2.0.0 don't have prototype, see: https://github.com/npm/ini/commit/032fbaf5f0b98fce70c8cc380e0d05177a9c9073

Handle that case