### PR TITLE
Adding toString() method to allow exporting of existing stores to JSO…

### DIFF
--- a/lib/nconf/provider.js
+++ b/lib/nconf/provider.js
@@ -583,6 +583,16 @@ Provider.prototype.save = function (value, callback) {
 };
 
 //
+// ### function toString ()
+// Instructs each provider to export to a string. Returns an string consisting
+// of all of the data which was actually exported.
+//
+Provider.prototype.toString = function () {
+  const result = this._execute('get', 1);
+  return JSON.stringify(result);
+}
+
+//
 // ### @private function _execute (action, syncLength, [arguments])
 // #### @action {string} Action to execute on `this.store`.
 // #### @syncLength {number} Function length of the sync version.

--- a/test/nconf.test.js
+++ b/test/nconf.test.js
@@ -22,6 +22,7 @@ describe('nconf, When using the nconf', () => {
     expect(typeof nconf.save).toBe('function');
     expect(typeof nconf.reset).toBe('function');
     expect(typeof nconf.required).toBe('function');
+    expect(typeof nconf.toString).toBe('function');
   });
   it("the use() method should instaniate the correct store", () => {
     nconf.use('memory');
@@ -102,6 +103,15 @@ describe('nconf, When using the nconf', () => {
           expect(store).toEqual({"foo": {"bar": {}}});
           done();
         });
+      })
+    })
+    describe("the toString() method", () => {
+      it("should respond with the exported store", () => {
+        nconf.use('memory');
+        nconf.load();
+        nconf.set('foo:bar:bazz', 'buzz');
+        const result = nconf.toString();
+        expect(result).toEqual('{"foo":{"bar":{"bazz":"buzz"}}}');
       })
     })
   })


### PR DESCRIPTION
Adding `toString()` function that allows exporting of entire store state to JSON string.