### PR TITLE
fix: avoid dynamic require (#386) (#387)

### DIFF
--- a/lib/nconf.js
+++ b/lib/nconf.js
@@ -21,12 +21,24 @@ nconf.version = require('../package.json').version;
 //
 // Setup all stores as lazy-loaded getters.
 //
-['argv', 'env', 'file', 'literal', 'memory'].forEach(function (store) {
-    var name = common.capitalize(store);
+nconf.__defineGetter__('Argv', function () {
+    return require('./nconf/stores/argv').Argv;
+});
 
-    nconf.__defineGetter__(name, function () {
-        return require('./nconf/stores/' + store)[name];
-    });
+nconf.__defineGetter__('Env', function () {
+    return require('./nconf/stores/env').Env;
+});
+
+nconf.__defineGetter__('File', function () {
+    return require('./nconf/stores/file').File;
+});
+
+nconf.__defineGetter__('Literal', function () {
+    return require('./nconf/stores/literal').Literal;
+});
+
+nconf.__defineGetter__('Memory', function () {
+    return require('./nconf/stores/memory').Memory;
 });
 
 //


### PR DESCRIPTION
(cherry picked from commit ce212b2f1dbf96cee001b5f621979c564638f0e7)

Backport from master branch to v0.x branch
