### PR TITLE
feat: add env prefix option

### DIFF
--- a/lib/nconf/stores/env.js
+++ b/lib/nconf/stores/env.js
@@ -21,6 +21,7 @@ var Env = exports.Env = function (options) {
   options        = options || {};
   this.type      = 'env';
   this.readOnly  = options.readOnly !== undefined ? options.readOnly : true;
+  this.prefix = options.prefix || '';
   this.whitelist = options.whitelist || [];
   this.lowerCase = options.lowerCase || false;
   this.parseValues = options.parseValues || false;
@@ -56,6 +57,15 @@ Env.prototype.loadEnv = function () {
   var self = this;
 
   var env = process.env;
+
+  if (this.prefix) {
+    env = {};
+    Object.keys(process.env).forEach(function (key) {
+      if (key.indexOf(self.prefix) === 0) {
+        env[key.replace(self.prefix, '')] = process.env[key];
+      } 
+    });
+  }
 
   if (this.lowerCase) {
     env = {};

--- a/test/stores/env.test.js
+++ b/test/stores/env.test.js
@@ -8,6 +8,7 @@
 var nconf = require('../../lib/nconf');
 
 process.env.DEEP__NESTED__VALUE = 'foo';
+process.env.DEEP2__NESTED__VALUE = 'bar';
 
 describe('nconf/stores/env, An instance of nconf.Env', () => {
   it("should have the correct methods defined", () => {
@@ -33,5 +34,18 @@ describe('nconf/stores/env, An instance of nconf.Env', () => {
 
     expect(env.accessSeparator).toBe('.');
     expect(env.get('DEEP.NESTED.VALUE')).toBe('foo');
-  })
+  });
+  it("should filter and strip prefix from environment variables", () => {
+    var env = new nconf.Env({prefix: 'DEEP2__'});
+    env.loadSync();
+    expect(env.get('DEEP__NESTED__VALUE')).toBeUndefined();
+    expect(env.get('NESTED__VALUE')).toBe('bar');
+  });
+  it("should filter and strip prefix from environment variables with input and access separator", () => {
+    var env = new nconf.Env({prefix: 'DEEP2__', accessSeparator: '.', inputSeparator: '__' });
+    env.loadSync();
+    console.log(env);
+    expect(env.get('DEEP.NESTED.VALUE')).toBeUndefined();
+    expect(env.get('NESTED.VALUE')).toBe('bar');
+  });
 });

--- a/test/stores/env.test.js
+++ b/test/stores/env.test.js
@@ -44,7 +44,6 @@ describe('nconf/stores/env, An instance of nconf.Env', () => {
   it("should filter and strip prefix from environment variables with input and access separator", () => {
     var env = new nconf.Env({prefix: 'DEEP2__', accessSeparator: '.', inputSeparator: '__' });
     env.loadSync();
-    console.log(env);
     expect(env.get('DEEP.NESTED.VALUE')).toBeUndefined();
     expect(env.get('NESTED.VALUE')).toBe('bar');
   });


### PR DESCRIPTION
This pull request introduces a new feature to env store `prefix`, allowing environment variables to be filtered and stripped of a specified prefix.

ref https://github.com/indexzero/nconf/issues/157

based on <https://www.dynaconf.com/envvars/>