### PR TITLE
add: parse function add (contents !== '' )

### DIFF
--- a/lib/nconf/stores/file.js
+++ b/lib/nconf/stores/file.js
@@ -205,7 +205,10 @@ File.prototype.stringify = function (format) {
 // `this.secure` is enabled.
 //
 File.prototype.parse = function (contents) {
-  var parsed = this.format.parse(contents);
+  var parsed = {};
+  if (contents !== '') {
+    parsed = this.format.parse(contents);
+  }
 
   if (this.secure) {
     var self = this;

--- a/lib/nconf/stores/file.js
+++ b/lib/nconf/stores/file.js
@@ -206,7 +206,8 @@ File.prototype.stringify = function (format) {
 //
 File.prototype.parse = function (contents) {
   var parsed = {};
-  if (contents !== '') {
+  if (typeof contents === 'string' && contents.trim() !== '') {
+    console.log('22222222')
     parsed = this.format.parse(contents);
   }
 


### PR DESCRIPTION
现在我有一个情况是，我用 nconf 生成一个配置文件 config.json ，然后使用监听方法监听 config.json 的变化，重新生成配置。但是用户可能为了方便直接清空文件内容，而不是保留 "{}" 最外层大括号。但这就会有 parse 为空报错问题，所以加了个空判断，如果文件已经生成了，但是文件内容为空，默认设置为空对象。可以吗？ 
Now I have a situation where I generate a configuration file named config.json using nconf, and then use the listening method to listen for changes in config.json and regenerate the configuration. However, users may directly clear the file content for convenience instead of keeping the outermost curly braces of "{}". However, this would lead to an error when parse is empty. Therefore, an empty judgment was added. If the file has been generated but its content is empty, the default setting is an empty object. Is it okay?
https://github.com/indexzero/nconf/issues/411
