### PR TITLE
fix: bug usage.js

### DIFF
--- a/usage.js
+++ b/usage.js
@@ -23,7 +23,7 @@ var single = new nconf.Provider({
 var multiple = new nconf.Provider({
   stores: [
     { name: 'user', type: 'file', file: path.join(__dirname, 'user-config.json') },
-    { name: 'global', type: 'global', file: path.join(__dirname, 'global-config.json') }
+    { name: 'global', type: 'file', file: path.join(__dirname, 'global-config.json') }
   ]
 });
 


### PR DESCRIPTION
    throw new Error('Cannot add store with unknown type: ' + type);
    ^

Error: Cannot add store with unknown type: global
    at exports.Provider.Provider.add (D:\gitee\huyunan\nconf\lib\nconf\provider.js:130:11)
    at D:\gitee\huyunan\nconf\lib\nconf\provider.js:187:12
    at Array.forEach (<anonymous>)
    at exports.Provider.Provider.init (D:\gitee\huyunan\nconf\lib\nconf\provider.js:185:33)
    at new exports.Provider (D:\gitee\huyunan\nconf\lib\nconf\provider.js:25:8)
    at Object.<anonymous> (D:\gitee\huyunan\nconf\usage.js:23:16)
    at Module._compile (node:internal/modules/cjs/loader:1196:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1250:10)
    at Module.load (node:internal/modules/cjs/loader:1074:32)
    at Function.Module._load (node:internal/modules/cjs/loader:909:12)